### PR TITLE
refactor: about 페이지 다국어 관련 하드코딩 제거 및 API 기반으로 변경

### DIFF
--- a/src/app/about/_components/menu-item.tsx
+++ b/src/app/about/_components/menu-item.tsx
@@ -1,42 +1,35 @@
-import { useTranslation } from 'react-i18next';
 import { FaFolder } from 'react-icons/fa';
 
 import { Button } from '@/components/ui/button';
-import { aboutMenuKoMap } from '@/constants/about';
 import { cn } from '@/lib/utils';
 import type { Menu } from '@/types/about';
 
 type Props = {
   menu: Menu;
+  menuName: string;
   selectedMenu: Menu;
   folderColor: string;
   onMenuClick: (menu: Menu) => () => void;
 };
 
-const MenuItem = ({ menu, selectedMenu, folderColor, onMenuClick }: Props) => {
-  const {
-    i18n: { language },
-  } = useTranslation();
-
-  return (
-    <Button
-      variant={selectedMenu === menu ? 'outline' : 'ghost'}
-      className='w-full justify-start rounded-none px-6 py-5'
-      onClick={onMenuClick(menu)}
-    >
-      <div className='flex items-center gap-2'>
-        <FaFolder size={20} className={folderColor} />
-        <span
-          className={cn(
-            'text-body-md text-slate-500 dark:text-slate-400',
-            selectedMenu === menu && 'text-slate-900 dark:text-slate-100'
-          )}
-        >
-          {language === 'ko' ? aboutMenuKoMap[menu] : menu}
-        </span>
-      </div>
-    </Button>
-  );
-};
+const MenuItem = ({ menu, menuName, selectedMenu, folderColor, onMenuClick }: Props) => (
+  <Button
+    variant={selectedMenu === menu ? 'outline' : 'ghost'}
+    className='w-full justify-start rounded-none px-6 py-5'
+    onClick={onMenuClick(menu)}
+  >
+    <div className='flex items-center gap-2'>
+      <FaFolder size={20} className={folderColor} />
+      <span
+        className={cn(
+          'text-body-md text-slate-500 dark:text-slate-400',
+          selectedMenu === menu && 'text-slate-900 dark:text-slate-100'
+        )}
+      >
+        {menuName}
+      </span>
+    </div>
+  </Button>
+);
 
 export default MenuItem;

--- a/src/app/about/_components/sidebar-content.tsx
+++ b/src/app/about/_components/sidebar-content.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import {
   Accordion,
@@ -7,7 +6,6 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import { aboutTabKoMap } from '@/constants/about';
 import { folderColors } from '@/constants/folder-colors';
 import { useAboutPageStore } from '@/store/use-about-page-store';
 import type { Menu, AboutTabKey, AboutCategoryItem } from '@/types/about';
@@ -16,9 +14,10 @@ import MenuItem from './menu-item';
 
 type Props = {
   tabs: AboutCategoryItem[];
+  categoryAboutData: AboutCategoryItem[];
 };
 
-const SidebarContent = ({ tabs }: Props) => {
+const SidebarContent = ({ tabs, categoryAboutData }: Props) => {
   const { selectedTab, selectedMenu, setTab, setMenu } = useAboutPageStore(state => ({
     selectedTab: state.selectedTab,
     selectedMenu: state.selectedMenu,
@@ -31,14 +30,10 @@ const SidebarContent = ({ tabs }: Props) => {
     [tabs, selectedTab]
   );
 
-  const {
-    i18n: { language },
-  } = useTranslation();
-
-  const handleMenuClick = (menu: string) => () => {
+  const handleMenuClick = (menu: Menu) => () => {
     const newTab = tabs.find(tab => tab.menus.includes(menu as Menu));
 
-    if (newTab && newTab.key !== selectedTab) setTab(newTab.key as AboutTabKey);
+    if (newTab && newTab.key !== selectedTab) setTab(newTab.key as AboutTabKey, menu);
     setMenu(menu as Menu);
   };
 
@@ -48,22 +43,28 @@ const SidebarContent = ({ tabs }: Props) => {
         <Accordion type='single' collapsible className='flex w-full flex-col gap-1 sm:flex-row'>
           {tabs.map(tab => {
             const tabMenus = tab.menus;
+            const tabName = tab.name;
 
             return (
               <AccordionItem key={tab.key} value={tab.key} className='flex-1'>
                 <AccordionTrigger className='rounded-none bg-gray-300 px-4 dark:bg-slate-700'>
-                  {language === 'ko' ? aboutTabKoMap[tab.key as AboutTabKey] : tab.key}
+                  {tabName}
                 </AccordionTrigger>
                 <AccordionContent className='border border-gray-300 pb-0 dark:border-slate-700'>
-                  {tabMenus.map((menu, idx) => (
-                    <MenuItem
-                      key={menu}
-                      menu={menu as Menu}
-                      selectedMenu={selectedMenu}
-                      folderColor={folderColors[idx]}
-                      onMenuClick={handleMenuClick}
-                    />
-                  ))}
+                  {tabMenus.map((menu, idx) => {
+                    const menuName = categoryAboutData.find(item => item.key === menu)?.name || '';
+
+                    return (
+                      <MenuItem
+                        key={menu}
+                        menu={menu as Menu}
+                        menuName={menuName}
+                        selectedMenu={selectedMenu}
+                        folderColor={folderColors[idx]}
+                        onMenuClick={handleMenuClick}
+                      />
+                    );
+                  })}
                 </AccordionContent>
               </AccordionItem>
             );
@@ -72,15 +73,20 @@ const SidebarContent = ({ tabs }: Props) => {
       </div>
 
       <div className='hidden lg:block'>
-        {menus.map((menu, idx) => (
-          <MenuItem
-            key={menu}
-            menu={menu as Menu}
-            selectedMenu={selectedMenu}
-            folderColor={folderColors[idx]}
-            onMenuClick={handleMenuClick}
-          />
-        ))}
+        {menus.map((menu, idx) => {
+          const menuName = categoryAboutData.find(item => item.key === menu)?.name || '';
+
+          return (
+            <MenuItem
+              key={menu}
+              menu={menu as Menu}
+              menuName={menuName}
+              selectedMenu={selectedMenu}
+              folderColor={folderColors[idx]}
+              onMenuClick={handleMenuClick}
+            />
+          );
+        })}
       </div>
     </>
   );

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,6 +5,7 @@ import Spinner from '@/components/ui/spinner';
 import { shared, page } from '@/constants/metadata';
 import { fetchAboutCategory, fetchAbout } from '@/lib/api/about';
 import { getLangFromCookie } from '@/lib/get-lang-from-cookie';
+import { AboutTabKey, Menu } from '@/types/about';
 import { Language } from '@/types/language';
 
 import About from './_components/about';
@@ -33,7 +34,11 @@ const AboutPage = async () => {
   const aboutCategoryData = await fetchAboutCategory({ lang });
   const tabs = aboutCategoryData.filter(item => item.type === 'tab');
 
-  const aboutData = await fetchAbout({ lang, tabKey: tabs[0].key, menuKey: tabs[0].menus[0] });
+  const aboutData = await fetchAbout({
+    lang,
+    tabKey: tabs[0].key as AboutTabKey,
+    menuKey: tabs[0].menus[0] as Menu,
+  });
 
   return (
     <Suspense
@@ -43,7 +48,7 @@ const AboutPage = async () => {
         </div>
       }
     >
-      <About tabs={tabs} initialData={aboutData} initialLang={lang} />
+      <About initialCategoryData={aboutCategoryData} initialData={aboutData} initialLang={lang} />
     </Suspense>
   );
 };

--- a/src/components/sidebar/sidebar-tab.tsx
+++ b/src/components/sidebar/sidebar-tab.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { tabIconMap } from '@/constants/about';
 import { cn } from '@/lib/utils';
 import { useAboutPageStore } from '@/store/use-about-page-store';
-import type { AboutTabKey, AboutCategoryItem } from '@/types/about';
+import type { AboutTabKey, AboutCategoryItem, Menu } from '@/types/about';
 
 type Props = {
   tabs: AboutCategoryItem[];
@@ -14,14 +14,15 @@ const SidebarTab = ({ tabs }: Props) => {
     setTab: state.setTab,
   }));
 
-  const handleTabClick = (tab: AboutTabKey) => () => {
-    setTab(tab);
+  const handleTabClick = (newTab: AboutTabKey) => () => {
+    const newMenu = tabs.find(tab => tab.key === newTab)?.menus[0];
+    setTab(newTab, newMenu as Menu);
   };
 
   return (
     <div className='hidden flex-col gap-2 border-r border-slate-400 px-2 py-4 lg:flex dark:border-slate-700'>
       {tabs.map(tab => {
-        const Icon = tabIconMap[tab.key];
+        const Icon = tabIconMap[tab.key as AboutTabKey];
 
         return (
           <Button
@@ -29,7 +30,7 @@ const SidebarTab = ({ tabs }: Props) => {
             size='lg'
             className='w-full'
             key={tab.key}
-            onClick={handleTabClick(tab.key)}
+            onClick={handleTabClick(tab.key as AboutTabKey)}
           >
             <Icon
               className={cn(

--- a/src/constants/about/index.ts
+++ b/src/constants/about/index.ts
@@ -1,57 +1,11 @@
 import { CgProfile } from 'react-icons/cg';
 import { MdWork, MdSportsEsports } from 'react-icons/md';
 
-import i18n from '@/lib/i18n/client';
-import type { AboutPageData, AboutTabKey, Menu, TabIconMap } from '@/types/about';
+import type { AboutTabKey, Menu, TabIconMap } from '@/types/about';
 
 export const initialTab: AboutTabKey = 'professional';
 
 export const initialMenu: Menu = 'experience';
-
-export const getAboutPageData = (): AboutPageData => ({
-  professional: {
-    icon: MdWork,
-    menu: {
-      experience: i18n.t('about:experience'),
-      'hard-skills': i18n.t('about:hard-skills'),
-      'soft-skills': i18n.t('about:soft-skills'),
-    },
-  },
-  personal: {
-    icon: CgProfile,
-    menu: {
-      bio: i18n.t('about:bio'),
-      interests: i18n.t('about:interests'),
-      education: i18n.t('about:education'),
-    },
-  },
-  hobbies: {
-    icon: MdSportsEsports,
-    menu: {
-      sports: i18n.t('about:sports'),
-      'favorite-games': i18n.t('about:favorite-games'),
-      'favorite-foods': i18n.t('about:favorite-foods'),
-    },
-  },
-});
-
-export const aboutTabKoMap: Record<AboutTabKey, string> = {
-  professional: '경력',
-  personal: '개인',
-  hobbies: '취미',
-};
-
-export const aboutMenuKoMap: Record<Menu, string> = {
-  experience: '직무 경험',
-  'hard-skills': '기술 역량',
-  'soft-skills': '대인 역량',
-  bio: '자기소개',
-  interests: '관심사',
-  education: '학력',
-  sports: '운동',
-  'favorite-games': '좋아하는 게임',
-  'favorite-foods': '좋아하는 음식',
-};
 
 export const tabIconMap: TabIconMap = {
   professional: MdWork,

--- a/src/store/__tests__/use-about-page-store.test.ts
+++ b/src/store/__tests__/use-about-page-store.test.ts
@@ -27,7 +27,7 @@ describe('useAboutPageStore', () => {
     );
 
     act(() => {
-      result.current.setTab('hobbies');
+      result.current.setTab('hobbies', 'sports');
     });
 
     expect(result.current.selectedTab).toBe('hobbies');
@@ -62,7 +62,7 @@ describe('useAboutPageStore', () => {
     );
 
     act(() => {
-      result.current.setTab('hobbies');
+      result.current.setTab('hobbies', 'sports');
       result.current.setMenu('favorite-games');
     });
 

--- a/src/store/use-about-page-store.ts
+++ b/src/store/use-about-page-store.ts
@@ -1,6 +1,6 @@
 import { useShallow } from 'zustand/react/shallow';
 
-import { initialTab, initialMenu, getAboutPageData } from '@/constants/about';
+import { initialTab, initialMenu } from '@/constants/about';
 import type { AboutTabKey, Menu } from '@/types/about';
 
 import { createStore } from '.';
@@ -8,12 +8,10 @@ import { createStore } from '.';
 type AboutPageStore = {
   selectedTab: AboutTabKey;
   selectedMenu: Menu;
-  setTab: (section: AboutTabKey) => void;
+  setTab: (section: AboutTabKey, initialMenu: Menu) => void;
   setMenu: (menu: Menu) => void;
   reset: () => void;
 };
-
-const aboutPageData = getAboutPageData();
 
 const initialState = {
   selectedTab: initialTab,
@@ -23,9 +21,11 @@ const initialState = {
 export const aboutPageStore = createStore<AboutPageStore>(
   set => ({
     ...initialState,
-    setTab: tab => {
-      const firstMenuKey = Object.keys(aboutPageData[tab].menu)[0] as Menu;
-      set({ selectedTab: tab, selectedMenu: firstMenuKey });
+    setTab: (tab, initialMenu) => {
+      set({
+        selectedTab: tab,
+        selectedMenu: initialMenu,
+      });
     },
     setMenu: menu => {
       set({ selectedMenu: menu });

--- a/src/types/about.ts
+++ b/src/types/about.ts
@@ -14,15 +14,6 @@ export type Menu =
   | 'favorite-games'
   | 'favorite-foods';
 
-type AboutMenuMap = Partial<Record<Menu, string>>;
-
-type AboutSection = {
-  icon: IconType;
-  menu: AboutMenuMap;
-};
-
-export type AboutPageData = Record<AboutTabKey, AboutSection>;
-
 export type TabIconMap = Record<AboutTabKey, IconType>;
 
 type AboutCategoryType = 'tab' | 'menu';
@@ -34,7 +25,7 @@ export type FetchAboutCategoryParams = {
 export type AboutCategoryItem = {
   id: string;
   type: AboutCategoryType;
-  key: AboutTabKey;
+  key: AboutTabKey | Menu;
   name: string;
   menus: Menu[];
 };


### PR DESCRIPTION
## 🔍 Overview

- about 페이지의 다국어 지원을 위해 하드코딩된 부분을 제거하고, API에서 제공하는 데이터에 기반하여 동적으로 렌더링되도록 변경
- `/constants/about`, '/types/about' 파일에 있는 불필요한 데이터 제거

## ✅ What’s Included

- [ ] Feature
- [ ] Bug Fix
- [ ] UI Enhancement
- [ ] Performance Improvement
- [x] Code Refactor
- [ ] Test Code
- [ ] Others (describe below)

## 📸 Screenshots

<!-- Add screenshots if the PR includes UI work -->

## 🔗 Related Issues

<!-- Add related issue numbers if applicable -->

- Closes #

## 💬 Additional Notes

<!-- Any extra context, TODOs, or implementation details -->